### PR TITLE
Copy all chat source files on build

### DIFF
--- a/docker/Dockerfile-chat
+++ b/docker/Dockerfile-chat
@@ -7,7 +7,7 @@ COPY ./chat/go.sum .
 RUN go mod download
 RUN go mod verify
 
-COPY ./chat/*.go ./
+COPY ./chat/. .
 RUN go build -o chat .
 
 FROM debian:buster-slim


### PR DESCRIPTION
Previously, the copy directive skipped files in subfolders, only catching those in the `main` package.