### PR TITLE
Add worker service for async message consumption

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,29 @@ services:
             - /www/www.destiny.gg/vendor/
         profiles:
             - dev
+    worker:
+        build:
+            context: .
+            dockerfile: ./docker/Dockerfile-website
+        command:
+            - php
+            - bin/worker
+            - messenger:consume
+            - async
+            - --limit=100
+            - --time-limit=3600
+            - --memory-limit=256M
+            - -vv
+        depends_on:
+            - redis
+            - mysql
+        volumes:
+            - ./website:/www/www.destiny.gg
+            - /www/www.destiny.gg/vendor/
+        deploy:
+            replicas: 2
+        profiles:
+            - dev
     chat:
         build:
             context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
             - --time-limit=3600
             - --memory-limit=256M
             - -vv
+        restart: unless-stopped
         depends_on:
             - redis
             - mysql


### PR DESCRIPTION
## Summary
- Add a `worker` service to `docker-compose.yml` that runs `bin/worker messenger:consume async` to process the async Messenger transport
- Runs 2 replicas with per-process limits (100 messages, 1h, 256M) so workers recycle cleanly; depends on redis and mysql and shares the website image/volumes
- Scoped to the `dev` profile

## Test plan
- [x] `docker compose --profile dev up worker` starts 2 worker replicas
- [x] Workers connect to redis/mysql and consume jobs from the `async` transport
- [x] Workers exit and restart after hitting the message/time/memory limits