### PR TITLE
Drop anonymous vendor exclusion from website / cron / worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
             - mysql
         volumes:
             - ./website:/www/www.destiny.gg
-            - /www/www.destiny.gg/vendor/ # Exclude to avoid overwriting in container.
         profiles:
             - dev
     cron:
@@ -39,7 +38,6 @@ services:
             - mysql
         volumes:
             - ./website:/www/www.destiny.gg
-            - /www/www.destiny.gg/vendor/
         profiles:
             - dev
     worker:
@@ -61,7 +59,6 @@ services:
             - mysql
         volumes:
             - ./website:/www/www.destiny.gg
-            - /www/www.destiny.gg/vendor/
         deploy:
             replicas: 2
         profiles:


### PR DESCRIPTION
The bind-mount-everything pattern with an anonymous volume punching a hole at vendor/ was the source of repeated developer confusion: the volume survives image rebuilds and `up --force-recreate`, so adding a Composer dep silently shadowed the freshly-built vendor and required a non-obvious `docker compose down -v` to recover.

Drop the exclusion and let the host's vendor/ shine through the bind mount instead. `composer require` on the host is now immediately visible to the running containers — no rebuild, no volume cleanup, no restart for source-only deps. The project's Composer dependencies are all pure PHP, so a macOS-installed vendor is byte-compatible with the Linux container.

Tradeoff: vendor reads cross the macOS bind-mount boundary, which is slower than a native Docker volume. With OPcache + realpath_cache and Docker Desktop's VirtioFS the gap is small in practice and worth the DX simplification.