### PR TITLE
Disable nginx caching for /service-worker.js

### DIFF
--- a/docker/nginx-config/dgg.local.conf.template
+++ b/docker/nginx-config/dgg.local.conf.template
@@ -84,6 +84,11 @@ server {
     # Allow `/.well-known` for custom Bluesky handle verification.
     location ~ ^/\.(?!well-known).* { deny all; }
 
+    location = /service-worker.js {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        expires off;
+    }
+
     location ~* \.(avif|jpg|jpeg|png|gif|ico|css|js|map|svg)$ {
         expires 12h;
     }


### PR DESCRIPTION
The blanket *.js rule applied 12h expiry to the service worker, which could leave intermediaries serving a stale SW after a deploy. Exact- match location wins over the regex rule, so only this one path is affected; hashed JS bundles still get the long cache.