### PR TITLE
Raise upload size limits to 100 MB

### DIFF
--- a/docker/nginx-config/dgg.local.conf.template
+++ b/docker/nginx-config/dgg.local.conf.template
@@ -60,6 +60,8 @@ server {
     access_log /dev/stdout;
     error_log /dev/stdout;
 
+    client_max_body_size 100M;
+
     error_page 403 /errors/403.html;
     error_page 404 /errors/404.html;
     error_page 500 /errors/500.html;

--- a/docker/php-config/php.ini-development
+++ b/docker/php-config/php.ini-development
@@ -677,7 +677,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 8M
+post_max_size = 105M
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -829,7 +829,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 100M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20


### PR DESCRIPTION
## Summary
- Bump nginx `client_max_body_size` to 100M so the proxy stops rejecting large admin uploads
- Raise PHP `upload_max_filesize` to 100M and `post_max_size` to 105M to match, leaving headroom for multipart overhead

## Test plan
- [x] Restart nginx + website containers and confirm PHP reports the new `upload_max_filesize` / `post_max_size`
- [x] Upload a ~100 MB file through the admin UI and verify it succeeds end-to-end
- [ ] Confirm a >100 MB upload is rejected with a clear error rather than a silent failure