### PR TITLE
Use dedicated Dockerfile-worker for dev worker service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,16 +43,7 @@ services:
     worker:
         build:
             context: .
-            dockerfile: ./docker/Dockerfile-website
-        command:
-            - php
-            - bin/worker
-            - messenger:consume
-            - async
-            - --limit=100
-            - --time-limit=3600
-            - --memory-limit=256M
-            - -vv
+            dockerfile: ./docker/Dockerfile-worker
         restart: unless-stopped
         depends_on:
             - redis

--- a/docker/Dockerfile-worker
+++ b/docker/Dockerfile-worker
@@ -1,0 +1,24 @@
+FROM php:8.4.4-fpm
+
+WORKDIR /www/www.destiny.gg
+COPY docker/php-config/php.ini-development $PHP_INI_DIR/php.ini
+
+RUN apt-get update && apt-get install -y \
+    zip \
+    git \
+    libxml2-dev
+
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install soap
+
+RUN pecl install -o -f redis \
+    &&  rm -rf /tmp/pear \
+    &&  docker-php-ext-enable redis
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+COPY ./website/composer.json .
+COPY ./website/composer.lock .
+RUN composer install
+
+ENTRYPOINT ["php", "bin/worker"]
+CMD ["messenger:consume", "async", "--limit=100", "--time-limit=3600", "--memory-limit=256M", "-vv"]

--- a/docker/Dockerfile-worker
+++ b/docker/Dockerfile-worker
@@ -1,4 +1,4 @@
-FROM php:8.4.4-fpm
+FROM php:8.4.4-cli
 
 WORKDIR /www/www.destiny.gg
 COPY docker/php-config/php.ini-development $PHP_INI_DIR/php.ini


### PR DESCRIPTION
## Summary
- Add `docker/Dockerfile-worker` based on `php:8.4-cli` with the PHP extensions and Composer install needed to run `bin/worker`.
- Switch the `worker` Compose service to build from the new Dockerfile and bake the `messenger:consume` invocation into the image's ENTRYPOINT/CMD instead of overriding `command` in `docker-compose.yml`.

## Test plan
- [x] `docker compose --profile dev build worker` succeeds
- [x] `docker compose --profile dev up -d worker` starts the worker and it consumes from the `async` queue
- [x] No regressions in other dev services