### PR TITLE
Serve admin uploads directly from the CDN

### DIFF
--- a/docker/nginx-config/dgg.local.conf.template
+++ b/docker/nginx-config/dgg.local.conf.template
@@ -37,6 +37,10 @@ server {
 
         expires 12h;
     }
+    location ^~ /uploads/ {
+        expires 12h;
+        try_files $uri =404;
+    }
     location ~ ^/\. { deny  all; }
     location ~* \.(avif|jpg|jpe?g|png|gif|ico|css|js|map|svg|eot|ttf|woff|woff2|wasm|otf)$ {
         expires 12h;


### PR DESCRIPTION
## Summary
- Route admin upload paths through the CDN host in the nginx dev config so local development matches production CDN behavior.

## Test plan
- [x] Start the dev stack and verify admin uploads load via the CDN port.