### PR TITLE
Allow self-hosted media in the CDN CSP

### DIFF
--- a/docker/nginx-config/dgg_csp.conf
+++ b/docker/nginx-config/dgg_csp.conf
@@ -5,7 +5,7 @@ set $EMBED_SCRIPT_SRC "script-src 'wasm-unsafe-eval' 'unsafe-inline' $domain:* h
 set $EMBED_OBJECT_SRC "object-src 'none'";
 set $EMBED_STYLE_SRC "style-src 'self' data: 'unsafe-inline' $domain:* fonts.googleapis.com";
 set $EMBED_IMAGE_SRC "img-src * data: blob:";
-set $EMBED_MEDIA_SRC "media-src *.live-video.net blob:";
+set $EMBED_MEDIA_SRC "media-src 'self' *.live-video.net blob:";
 set $EMBED_FRAME_SRC "frame-src 'self' player.kick.com kick.com *.vimeo.com rumble.com odysee.com *.facebook.com https://www.google.com www.twitch.tv player.twitch.tv googleads.g.doubleclick.net player.kick.cx";
 set $EMBED_FONT_SRC "font-src data: $domain:* fonts.googleapis.com fonts.gstatic.com";
 set $EMBED_CONNECT_SRC "connect-src *.live-video.net 'self' wss://$domain:* $domain:* wss://sockets.streamlabs.com sockets.streamlabs.com wss://alerts.designbyhumans.com alerts.designbyhumans.com *.rustlesearch.dev";


### PR DESCRIPTION
## Summary
- Add `'self'` to the CDN's `media-src` so admin uploads (mp4/mp3) served by the local adapter play back in the browser. Previously the policy only allowed `*.live-video.net` and `blob:`, so the browser's default media player refused to load same-origin media.

## Test plan
- [x] `docker compose --profile dev restart nginx`
- [x] Upload an mp4 with the local storage adapter; opening its URL in a new tab plays inline instead of being blocked.
- [x] Upload an mp3; same — plays in the browser's default audio player.
- [x] `curl -kI` on an upload URL shows `Content-Security-Policy: ...; media-src 'self' *.live-video.net blob:; ...`.