### PR TITLE
Allow site-hosted and R2 audio under the CSP

### DIFF
--- a/docker/Dockerfile-worker
+++ b/docker/Dockerfile-worker
@@ -6,6 +6,7 @@ COPY docker/php-config/php.ini-development $PHP_INI_DIR/php.ini
 RUN apt-get update && apt-get install -y \
     zip \
     git \
+    ffmpeg \
     libxml2-dev \
     libpng-dev \
     libjpeg-dev \

--- a/docker/nginx-config/dgg.local.conf.template
+++ b/docker/nginx-config/dgg.local.conf.template
@@ -117,7 +117,7 @@ server {
             set $OBJECT_SRC "object-src 'none'";
             set $STYLE_SRC "style-src 'self' data: 'unsafe-inline' $domain:* fonts.googleapis.com";
             set $IMAGE_SRC "img-src * data: blob:";
-            set $MEDIA_SRC "media-src *.live-video.net blob:";
+            set $MEDIA_SRC "media-src 'self' $domain:* *.live-video.net blob:";
             set $FRAME_SRC "frame-src 'self' player.kick.com kick.com *.vimeo.com rumble.com odysee.com *.facebook.com https://www.youtube.com youtube.com https://www.google.com www.twitch.tv clips.twitch.tv player.twitch.tv googleads.g.doubleclick.net player.kick.cx";
 
             set $FONT_SRC "font-src data: $domain:* fonts.googleapis.com fonts.gstatic.com";

--- a/docker/nginx-config/dgg.local.conf.template
+++ b/docker/nginx-config/dgg.local.conf.template
@@ -117,7 +117,7 @@ server {
             set $OBJECT_SRC "object-src 'none'";
             set $STYLE_SRC "style-src 'self' data: 'unsafe-inline' $domain:* fonts.googleapis.com";
             set $IMAGE_SRC "img-src * data: blob:";
-            set $MEDIA_SRC "media-src 'self' $domain:* *.live-video.net blob:";
+            set $MEDIA_SRC "media-src 'self' $domain:* *.r2.dev *.live-video.net blob:";
             set $FRAME_SRC "frame-src 'self' player.kick.com kick.com *.vimeo.com rumble.com odysee.com *.facebook.com https://www.youtube.com youtube.com https://www.google.com www.twitch.tv clips.twitch.tv player.twitch.tv googleads.g.doubleclick.net player.kick.cx";
 
             set $FONT_SRC "font-src data: $domain:* fonts.googleapis.com fonts.gstatic.com";


### PR DESCRIPTION
## Problem

`media-src` listed only `*.live-video.net` and `blob:`, so any `<audio>` playing a file the site itself serves was refused by the browser with:

```
MEDIA_ELEMENT_ERROR: Media load rejected by URL safety check
```

That covers every TTS clip — the queue, donation detail, OBS player, playback dock — plus the stored reference and sample clips on the voice & sound form. It reproduces on `/admin/tts/library/voices/<id>/edit`, where the player sat at `0:00` and never played.

## Changes

- Add `'self'` and `$domain:*` so the local CDN can be played.
- Add `*.r2.dev` so the R2 uploads driver works too. R2 serves objects from Cloudflare's `pub-<id>.r2.dev` hostname, a different origin again, so switching the driver otherwise re-broke playback.

## Notes

The header browsers actually enforce on app pages is built in the `if` block inside `location ~ \.php$`. `dgg_csp.conf` also sets a `media-src`, but only the CDN server block includes it — it is the `/embed` policy and is deliberately left alone, since the chat embed plays no site-hosted audio.

Only the dev config needs `*.r2.dev`; a deployed environment fronts the bucket with a CDN subdomain. The matching production fix lives in the website repo.

## Verification

Captured the `securitypolicyviolation` event before the change (`effectiveDirective: "media-src"`) and confirmed it was gone after. The reference clip on the taylor voice now reports its duration and plays, served from R2.