### PR TITLE
Expose the TTS webhook callback through a tunnel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ live-ws ↔ redis (pub/sub for live streaming updates)
 | File | Purpose |
 |------|---------|
 | `docker-compose.yml` | Service orchestration |
-| `.env` | Port configuration (`PORT_WWW`, `PORT_CDN`, `PORT_WIKI`) |
+| `.env` | Port configuration (`PORT_WWW`, `PORT_CDN`, `PORT_WIKI`) and `NGROK_DOMAIN` (tunnel host for TTS webhooks; blank disables that vhost) |
 | `website/config/config.local.php` | Website app config (CORS, crypto keys, embeds) |
 | `chat/settings.cfg` | Chat server settings (Redis, MySQL, API) |
 | `live-ws/.env` | Live WS config (ports, API URL/key, Redis) |

--- a/docker/nginx-config/dgg.local.conf.template
+++ b/docker/nginx-config/dgg.local.conf.template
@@ -136,3 +136,41 @@ server {
         include       fastcgi.conf;
     }
 }
+
+# Public tunnel vhost. Replicate delivers TTS prediction results by webhook,
+# which it can only do if the callback is reachable from the internet, so an
+# ngrok tunnel forwards here. Matched by the tunnel hostname, so ordinary
+# local browsing (Host: 127.0.0.1) still gets the full site above.
+#
+# Only the webhook path is served — everything else 404s. This environment
+# runs with allowImpersonation on, so exposing the whole site would hand
+# anyone who finds the tunnel an admin session.
+server {
+    listen 8080 ssl;
+    server_name wandering-quiet-otter.ngrok-free.dev;
+    root /www/www.destiny.gg/public;
+
+    ssl_certificate /etc/nginx/certs/dgg.pem;
+    ssl_certificate_key /etc/nginx/certs/dgg-key.pem;
+
+    access_log /dev/stdout;
+    error_log /dev/stdout;
+
+    location ~ ^/api/tts/webhook/ {
+        rewrite ^ /index.php last;
+    }
+
+    # internal: reachable only via the rewrite above, so a direct request for
+    # /index.php cannot use this vhost to reach the rest of the app.
+    location = /index.php {
+        internal;
+
+        fastcgi_pass  website:9000;
+        fastcgi_index index.php;
+        include       fastcgi.conf;
+    }
+
+    location / {
+        return 404;
+    }
+}

--- a/docker/nginx-config/dgg.local.conf.template
+++ b/docker/nginx-config/dgg.local.conf.template
@@ -145,9 +145,13 @@ server {
 # Only the webhook path is served — everything else 404s. This environment
 # runs with allowImpersonation on, so exposing the whole site would hand
 # anyone who finds the tunnel an admin session.
+#
+# setup.sh replaces the hostname below with NGROK_DOMAIN from .env. Left
+# unset it stays .invalid, a reserved TLD that no request can arrive for, so
+# this block is inert until a tunnel is actually configured.
 server {
     listen 8080 ssl;
-    server_name wandering-quiet-otter.ngrok-free.dev;
+    server_name tunnel.invalid;
     root /www/www.destiny.gg/public;
 
     ssl_certificate /etc/nginx/certs/dgg.pem;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -54,11 +54,19 @@ echo
 COMPOSE_PROJECT_NAME=$(prompt_value COMPOSE_PROJECT_NAME dockerstiny "Compose project name")
 echo
 
+# Replicate delivers TTS results by webhook and cannot reach localhost, so
+# generating TTS locally needs a tunnel pointed at the callback. Optional —
+# everything except TTS generation works without one.
+info "Configure the TTS webhook tunnel (leave blank if you are not generating TTS):"
+NGROK_DOMAIN=$(prompt_value NGROK_DOMAIN "" "ngrok domain, e.g. your-name.ngrok-free.dev")
+echo
+
 cat > "$ENV_FILE" <<EOF
 COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
 PORT_WWW=$PORT_WWW
 PORT_CDN=$PORT_CDN
 PORT_WIKI=$PORT_WIKI
+NGROK_DOMAIN=$NGROK_DOMAIN
 EOF
 ok "Port configuration saved to .env"
 
@@ -124,11 +132,14 @@ copy_config docker/live-ws-config/.env              live-ws/.env
 
 info "Generating config files from templates..."
 
-# Generate nginx config from template (replace known defaults with configured ports)
+# Generate nginx config from template (replace known defaults with configured
+# ports, and the webhook tunnel vhost with the configured ngrok domain — left
+# blank the placeholder stays, keeping that vhost unmatchable)
 sed \
   -e "s/listen 8081 ssl;/listen $PORT_CDN ssl;/" \
   -e "s/listen 8080 ssl;/listen $PORT_WWW ssl;/" \
   -e "s/:8080/:$PORT_WWW/g" \
+  -e "s/server_name tunnel\.invalid;/server_name ${NGROK_DOMAIN:-tunnel.invalid};/" \
   docker/nginx-config/dgg.local.conf.template > docker/nginx-config/dgg.local.conf
 
 # Generate wiki config from template


### PR DESCRIPTION
## Problem

Replicate returns TTS synthesis results by webhook. The callback URL is built from the site origin, which is `localhost` here, so Replicate can never deliver it — a locally generated request stays in `PROCESSING` until it is timed out. TTS generation cannot complete in this environment at all.

## Changes

**A webhook-only vhost for the tunnel.** A second server block on 8080, matched by the tunnel hostname, so ordinary local browsing (`Host: 127.0.0.1`) still gets the full site from the block above.

Only `/api/tts/webhook/` is served; everything else returns 404. This matters: the environment runs with `allowImpersonation` on, so tunnelling the whole site would hand anyone who found the URL an admin session, and tunnel URLs are not secret. `/index.php` is marked `internal` so it is reachable only through the webhook rewrite — without that, one location would have re-exposed the entire app.

**The hostname is configurable.** `setup.sh` prompts for it alongside the ports and persists `NGROK_DOMAIN` in `.env`, then substitutes it when generating the nginx config. A blank answer is accepted, since a tunnel is only needed to generate TTS locally; the placeholder then stays `tunnel.invalid`, a reserved TLD that can never resolve, so the block is inert rather than absent and generation stays a plain substitution.

## Pairs with

`tts.webhook_origin` in the website config, which points the callback at the tunnel without moving `origin` itself — `origin` also builds OAuth redirect URIs and subscription return URLs, and aiming those at a host that serves only the webhook path would break local login and subscription checkout.

## Verification

Routing was checked from the public internet with a tunnel running, not only with simulated `Host` headers:

| Public request | Result |
| --- | --- |
| `POST /api/tts/webhook/<token>` | 401 — reaches PHP, rejected by signature check |
| `GET /` | 404 |
| `GET /impersonate?username=admin` | 404 |
| `GET /admin/tts/library` | 404 |
| `GET /index.php` | 404 |

The 401 is the meaningful result: the request traversed ngrok, the tunnel vhost, and PHP, and was refused only because the token was fake. A real callback then completed a generation end to end. ngrok forwards the original `Host` by default, so no `--host-header` flag is needed. Config generation was checked with `NGROK_DOMAIN` both set and blank, and nginx accepts both.