### PR TITLE
Fix TTS in the dev environment

### DIFF
--- a/docker/Dockerfile-website
+++ b/docker/Dockerfile-website
@@ -6,6 +6,7 @@ COPY docker/php-config/php.ini-development $PHP_INI_DIR/php.ini
 RUN apt-get update && apt-get install -y \
     zip \
     git \
+    ffmpeg \
     libxml2-dev
 
 RUN docker-php-ext-install pdo_mysql

--- a/docker/Dockerfile-website
+++ b/docker/Dockerfile-website
@@ -6,7 +6,6 @@ COPY docker/php-config/php.ini-development $PHP_INI_DIR/php.ini
 RUN apt-get update && apt-get install -y \
     zip \
     git \
-    ffmpeg \
     libxml2-dev
 
 RUN docker-php-ext-install pdo_mysql

--- a/docker/live-ws-config/.env
+++ b/docker/live-ws-config/.env
@@ -5,4 +5,4 @@ REDIS_URL=redis://redis:6379
 REDIS_API_KEY=dggApi
 NODE_ENV=development
 API_URL=https://host.docker.internal:8080/api
-API_KEY=aboycalledsuesucks
+API_KEY=blubstinya

--- a/docker/nginx-config/dgg.local.conf.template
+++ b/docker/nginx-config/dgg.local.conf.template
@@ -79,6 +79,19 @@ server {
         proxy_set_header Host $host;
     }
 
+    # The OBS player connects to $WS_API_URL/tts, which is /dggApi/tts here.
+    # live-ws routes upgrades by exact pathname, so the prefix has to come off
+    # or the socket falls through to the main dggApi server: the TTS room then
+    # looks empty, and an empty room deliberately holds the queue, so playback
+    # never advances past the clip that is airing.
+    location /dggApi/tts {
+        proxy_pass http://live-ws:42069/tts;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+    }
+
     location /dggApi {
         proxy_pass http://live-ws:42069;
         proxy_http_version 1.1;

--- a/docker/nginx-config/dgg.local.conf.template
+++ b/docker/nginx-config/dgg.local.conf.template
@@ -79,11 +79,14 @@ server {
         proxy_set_header Host $host;
     }
 
+    # live-ws serves each socket at an exact pathname ("/" and "/tts") and
+    # rejects anything else, so the /dggApi prefix this environment adds — prod
+    # gives live-ws its own subdomain — has to come off before proxying. Both
+    # locations do that, this one explicitly: the longer prefix wins, and
+    # routing /dggApi/tts through the generic location below would rewrite it to
+    # "//tts" (nginx appends the unmatched remainder to the proxy_pass URI).
+    #
     # The OBS player connects to $WS_API_URL/tts, which is /dggApi/tts here.
-    # live-ws routes upgrades by exact pathname, so the prefix has to come off
-    # or the socket falls through to the main dggApi server: the TTS room then
-    # looks empty, and an empty room deliberately holds the queue, so playback
-    # never advances past the clip that is airing.
     location /dggApi/tts {
         proxy_pass http://live-ws:42069/tts;
         proxy_http_version 1.1;
@@ -92,8 +95,10 @@ server {
         proxy_set_header Host $host;
     }
 
+    # The main API socket, which the site opens at $WS_API_URL itself. The
+    # trailing slash strips the prefix, so live-ws receives "/".
     location /dggApi {
-        proxy_pass http://live-ws:42069;
+        proxy_pass http://live-ws:42069/;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;

--- a/docker/nginx-config/dgg_csp.conf
+++ b/docker/nginx-config/dgg_csp.conf
@@ -5,7 +5,7 @@ set $EMBED_SCRIPT_SRC "script-src 'wasm-unsafe-eval' 'unsafe-inline' $domain:* h
 set $EMBED_OBJECT_SRC "object-src 'none'";
 set $EMBED_STYLE_SRC "style-src 'self' data: 'unsafe-inline' $domain:* fonts.googleapis.com";
 set $EMBED_IMAGE_SRC "img-src * data: blob:";
-set $EMBED_MEDIA_SRC "media-src 'self' *.live-video.net blob:";
+set $EMBED_MEDIA_SRC "media-src 'self' $domain:* *.r2.dev *.live-video.net blob:";
 set $EMBED_FRAME_SRC "frame-src 'self' player.kick.com kick.com *.vimeo.com rumble.com odysee.com *.facebook.com https://www.google.com www.twitch.tv player.twitch.tv googleads.g.doubleclick.net player.kick.cx";
 set $EMBED_FONT_SRC "font-src data: $domain:* fonts.googleapis.com fonts.gstatic.com";
 set $EMBED_CONNECT_SRC "connect-src *.live-video.net 'self' wss://$domain:* $domain:* wss://sockets.streamlabs.com sockets.streamlabs.com wss://alerts.designbyhumans.com alerts.designbyhumans.com *.rustlesearch.dev";


### PR DESCRIPTION
Three separate breakages that each stopped TTS from working in the local dev
environment. All of it is dev config — no application code.

### Route the TTS playback socket to the TTS server

The OBS player connects to `$WS_API_URL/tts`, which resolves to `/dggApi/tts`
here. The existing `/dggApi` proxy does not strip its prefix, and live-ws
matches upgrade handlers on the exact pathname, so the socket fell through to
the default handler and joined the main dggApi server instead: the player never
received the connect-time state sync, and never counted as a TTS client.

Adds a `/dggApi/tts` location that strips the prefix so the upgrade reaches the
TTS server.

### Point live-ws at the api private key

live-ws was seeded with the value of the chat key while the variable is named
`API_KEY`. It went unnoticed because the only endpoint it used to call,
`/api/auth`, accepts either key — but the TTS routes accept only `api`, so every
attempt to advance the queue answered 403 and the queue stalled behind the
airing clip.

Every endpoint live-ws calls (`/api/auth`, `/api/media`, `/api/tts/current`,
`/api/tts/advance`) accepts the api key, so it gets that rather than widening the
TTS routes to accept the chat key.

### Allow TTS audio under the embed CSP

Mirrors the website's embed-CSP fix: adds `$domain:*` and `*.r2.dev` to the embed
`media-src` so chat's "Play TTS" button can load clips from the dev CDN / R2
bucket instead of being blocked.

### Strip the /dggApi prefix on the main socket too

live-ws is dropping its catch-all handler for unrouted paths, so every served
path has to arrive as live-ws names it: `/` for the main API socket, `/tts` for
playback. The generic `/dggApi` location passed the URI through unchanged, so
the main socket arrived as `/dggApi` and only worked via that catch-all.

The trailing slash on `proxy_pass` strips the prefix, making the socket arrive
as `/` — which is what it is in production, where live-ws has its own subdomain
rather than a path prefix. Safe to merge ahead of the live-ws change, since `/`
is served either way.

### Note on the commit list

ffmpeg is added to the website image and then removed again, so there is no net
change to any Dockerfile. Upload durations moved to getID3 in PHP in the
meantime; only the worker still needs the binary, for concatenating segments.

### Verifying

With `docker compose --profile dev up -d`:

- `https://localhost:$PORT_WWW/tts/player?debug` shows `connected`, then
  `playing @ …` when a clip airs — rather than sitting idle.
- The queue advances on its own past the airing clip (previously 403s from
  `/api/tts/advance` in the live-ws logs).
- Chat's "Play TTS" plays a clip with no `media-src` violation in the console.
