### PR TITLE
Document the command that actually runs migrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ npm run dev      # watch mode
 npm run build    # production build
 
 # Database migrations (from website container)
-docker compose --profile dev exec website php migrations.php
+docker compose --profile dev exec website vendor/bin/doctrine-migrations migrate --no-interaction
 
 # Generate a diff migration (from website container)
 docker compose --profile dev exec website vendor/bin/doctrine-migrations migrations:diff


### PR DESCRIPTION
`php migrations.php` does not run migrations. That file is Doctrine's configuration — a bare `return [...]` of `table_storage`, `migrations_paths` and friends — so PHP evaluates it, discards the array, and exits **0 with no output**.

The silent success is what makes it costly: following the documented command leaves the dev database unmigrated while reporting nothing wrong, and it surfaces later as a missing column rather than as a failed command. It also passes CI unnoticed, since the test database rebuilds from migrations independently of this command.

Swapped in the runner — the same binary the `migrations:diff` line directly below already uses:

```
docker compose --profile dev exec website vendor/bin/doctrine-migrations migrate --no-interaction
```

`--no-interaction` is there because Doctrine otherwise prompts for confirmation, and under `exec -T` there is no terminal to answer it.

Verified by running the new line verbatim against the running dev stack: `[OK] Already at the latest version`.
